### PR TITLE
fix(ci): add rebase before push to prevent race condition

### DIFF
--- a/.github/workflows/generate-chart.yml
+++ b/.github/workflows/generate-chart.yml
@@ -47,6 +47,7 @@ jobs:
           git add assets/papers_by_year.png
           if ! git diff --cached --quiet; then
             git commit -m "chore: update papers by year chart"
+            git pull --rebase origin main
             git push origin HEAD:main
           else
             echo "No changes to commit."

--- a/.github/workflows/sort-and-generate.yml
+++ b/.github/workflows/sort-and-generate.yml
@@ -52,6 +52,7 @@ jobs:
           git add README.md subjects
           if ! git diff --cached --quiet; then
             git commit -m "chore: auto-sort table and generate subject pages"
+            git pull --rebase origin main
             git push origin HEAD:main
           else
             echo "No changes to commit."


### PR DESCRIPTION
## Summary
- Adds `git pull --rebase origin main` right before `git push` in both CI workflows
- Fixes race condition where one workflow's push fails because the other workflow pushed first

## Test plan
- [ ] Verify CI workflows pass after merging
- [ ] Confirm no more "fetch first" errors when both workflows run concurrently

🤖 Generated with [Claude Code](https://claude.com/claude-code)