### PR TITLE
[codex] Add recent math benchmark papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 | **[FIMO: A Challenge Formal Dataset for Automated Theorem Proving](https://arxiv.org/abs/2309.04295)** | Benchmark, ATP | arXiv 2023 |  |
 | **[Finding Kissing Numbers with Game-theoretic Reinforcement Learning](https://arxiv.org/abs/2511.13391)** | Discrete Geometry, RL | arXiv 2025 | [Code](https://github.com/CDM1619/PackingStar) |
 | **[First Proof](https://arxiv.org/abs/2602.05192)** | Benchmark, LLM | arXiv 2026 | [Website](https://1stproof.org/) |
+| **[First Proof Second Batch](https://arxiv.org/abs/2606.18119)** | Benchmark, LLM | arXiv 2026 |  |
 | **[Flow-based Extremal Mathematical Structure Discovery](https://www.arxiv.org/abs/2601.18005)** | Combinatorics, Transformer, Discrete Geometry, RL | arXiv 2026 | [Code](https://github.com/berczig/FlowBoost) |
 | **[FlowBoost Reveals Phase Transitions and Spectral Structure in Finite Free Information Inequalities](https://arxiv.org/abs/2604.11922)** | Analysis | arXiv 2026 |  |
 | **[Forbidden Sidon subsets of perfect difference sets, featuring a human-assisted proof](https://doi.org/10.1073/pnas.2531760123)** | Combinatorics, Number Theory, LLM, ATP | Proceedings of the National Academy of Sciences 2026 | [Code](https://borisalexeev.com/papers/Erdos707.lean) [arXiv](https://arxiv.org/abs/2510.19804) |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 
-A curated list of 174 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
+A curated list of 173 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
 
 See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main/CONTRIBUTING.md) for contribution.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 
-A curated list of 173 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
+A curated list of 174 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
 
 See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main/CONTRIBUTING.md) for contribution.
 
@@ -110,6 +110,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 | **[LemmaBench: A Live, Research-Level Benchmark to Evaluate LLM Capabilities in Mathematics](https://arxiv.org/abs/2602.24173)** | Benchmark, LLM | arXiv 2026 |  |
 | **[Linear algebra with transformers](https://openreview.net/forum?id=Hp4g7FAXXG)** | Linear Algebra, Symbolic Computation, Transformer | TMLR 2022 | [Code](https://github.com/facebookresearch/LAWT) |
 | **[Lower bounds for multivariate independence polynomials and their generalisations](https://www.arxiv.org/abs/2602.02450)** | Combinatorics, LLM | arXiv 2026 | [Chat Logs](https://github.com/google-deepmind/superhuman/tree/main/aletheia) |
+| **[MA-ProofBench: A Two-Tiered Evaluation of LLMs for Theorem Proving in Mathematical Analysis](https://arxiv.org/abs/2606.13782)** | Benchmark, ATP, LLM | arXiv 2026 |  |
 | **[Machine Learning Approaches to the Shafarevich-Tate Group of Elliptic Curves](https://www.worldscientific.com/doi/abs/10.1142/S2810939225400015)** | Number Theory, Neural Network, Decision Tree | IJDSMS 2024 | [Code](https://github.com/barinderbanwait/ml_rnt) |
 | **[Machine learning assisted exploration for affine Deligne-Lusztig varieties](https://doi.org/10.1007/s42543-024-00086-8)** | Number Theory, Representation Theory | Peking Math J 2024 | [Code](https://github.com/Jinpf314/ML4ADLV/) |
 | **[Machine learning BPS spectra and the gap conjecture](https://journals.aps.org/prd/abstract/10.1103/PhysRevD.110.046016)** | Mathematical Physics, PCA | Physical Review D 2024 |  |

--- a/assets/papers.json
+++ b/assets/papers.json
@@ -1479,18 +1479,6 @@
       ]
     },
     {
-      "title": "MA-ProofBench: A Two-Tiered Evaluation of LLMs for Theorem Proving in Mathematical Analysis",
-      "url": "https://arxiv.org/abs/2606.13782",
-      "subjects": [
-        "Benchmark",
-        "ATP",
-        "LLM"
-      ],
-      "venue": "arXiv",
-      "year": 2026,
-      "links": []
-    },
-    {
       "title": "Machine Learning Approaches to the Shafarevich-Tate Group of Elliptic Curves",
       "url": "https://www.worldscientific.com/doi/abs/10.1142/S2810939225400015",
       "subjects": [

--- a/assets/papers.json
+++ b/assets/papers.json
@@ -1479,6 +1479,18 @@
       ]
     },
     {
+      "title": "MA-ProofBench: A Two-Tiered Evaluation of LLMs for Theorem Proving in Mathematical Analysis",
+      "url": "https://arxiv.org/abs/2606.13782",
+      "subjects": [
+        "Benchmark",
+        "ATP",
+        "LLM"
+      ],
+      "venue": "arXiv",
+      "year": 2026,
+      "links": []
+    },
+    {
       "title": "Machine Learning Approaches to the Shafarevich-Tate Group of Elliptic Curves",
       "url": "https://www.worldscientific.com/doi/abs/10.1142/S2810939225400015",
       "subjects": [


### PR DESCRIPTION
## Summary
- add `MA-ProofBench: A Two-Tiered Evaluation of LLMs for Theorem Proving in Mathematical Analysis` to the curated list in `README.md`
- add `First Proof Second Batch` to the curated list in `README.md`
- leave `assets/papers.json` unchanged
- leave the top-level paper count unchanged because it is auto-managed

## Why these papers
`MA-ProofBench` is a strong fit because it is a math-specific formal reasoning benchmark focused on analysis rather than a generic software-verification system.

`First Proof Second Batch` is the strongest non-ATP candidate from the same time window because it evaluates AI systems on research-level mathematics problems contributed by working mathematicians across multiple fields.

## Search scope
I screened recent arXiv papers from June 11, 2026 through June 18, 2026 across terms including:
- mathematical discovery
- AI for mathematics
- machine learning for mathematics
- automated conjecture discovery
- research-level mathematics benchmark
- formal mathematics
- automated theorem proving
- Lean / Isabelle / Coq / Rocq

## Selection notes
I broadened the search beyond ATP after the initial pass was too concentrated on formal-verification-style papers.

I did not include nearby candidates such as `IsabeLLM` and `Planning to Hammer` because they focus on software or systems verification rather than mathematics itself.

I considered `Mapping Mathematical Hardness: Machine-Assisted Conjecture Discovery and the Quantification of Non-Triviality`, but it looked less established than `First Proof Second Batch` as a repository addition for this pass.

I excluded `Harnessing the Collective Intelligence of AI Agents in the Wild for New Discoveries` because its arXiv posting date is June 9, 2026, outside this run's one-week window.

## Validation
- verified the PR diff is README-only