### PR TITLE
[codex] Add arXiv papers and paper workflow skill

### DIFF
--- a/.agents/skills/awesome-ai-for-math-paper/SKILL.md
+++ b/.agents/skills/awesome-ai-for-math-paper/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: awesome-ai-for-math-paper
+description: Add paper links to the awesome-ai-for-math repository README. Use when the user gives an arXiv, DOI, proceedings, journal, or paper URL and asks to add it to awesome-ai-for-math, update the README paper table, classify topics, find associated resources such as GitHub repositories, update an existing paper-add PR, or commit the change with a Codex co-author trailer.
+---
+
+# Awesome AI For Math Paper
+
+## Workflow
+
+Use this workflow for the `awesome-ai-for-math` repository unless the user gives different instructions.
+
+1. Inspect state first.
+   - Run `git status -sb`.
+   - Read the relevant README rows around the alphabetical insertion point.
+   - If a PR branch is already active for paper additions, continue on it. If starting from `main`, create a `codex/...` branch before committing.
+
+2. Fetch paper metadata from primary sources.
+   - For arXiv links, read the arXiv abstract page or Atom API record.
+   - Extract title, submission year, abstract, arXiv subjects, comments, and visible resource links.
+   - Do not rely only on the user-provided title.
+
+3. Choose README fields.
+   - Title: exact paper title as rendered by the source, linked to the paper URL.
+   - Subject(s): prefer existing README tags. Use mathematical domain tags first, then method tags such as `LLM`, `ATP`, `RL`, `Transformer`, `Neural Network`, or `Benchmark`.
+   - Venue & Year: use `arXiv YYYY` unless a published venue is confirmed.
+   - Links & Resources: include official resources discovered from the paper page, abstract, paper PDF, repository search, author pages, or clearly related existing project repos.
+
+4. Search for associated resources.
+   - Check the paper page and PDF for URLs such as GitHub, GitLab, project pages, datasets, notebooks, Lean artifacts, or chat logs.
+   - Search the web for the exact title plus `GitHub`, `code`, and named systems from the abstract.
+   - Verify candidate repositories exist before adding them.
+   - If a paper has a dedicated repo, prefer it over a shared system repo. Example: use `[Code](https://github.com/frenzymath/iteris)` for Iteris rather than the shared Rethlas repo.
+   - If a known shared project has an existing README label style and no more-specific repo is confirmed, reuse it. Example: use `[Code (Rethlas)](https://github.com/frenzymath/Rethlas)` for Rethlas-based papers.
+   - Use `Code` only for actual executable code or formal artifacts. Use `Chat Logs` for transcripts or prompt/response records.
+
+5. Edit README only unless the user asks for generated/site data updates.
+   - Bump the paper count in the intro.
+   - Insert the row alphabetically by title.
+   - Keep markdown table formatting consistent.
+   - Do not edit `assets/papers.json` or charts when the user says README-only.
+
+6. Validate.
+   - Run `rg -c '^\\| \\*\\*\\[' README.md` and confirm the count matches the intro.
+   - Run `git diff -- README.md` and inspect the exact row(s).
+   - Confirm `git status -sb` shows only intended files.
+
+7. Commit and publish when requested.
+   - Stage explicit files.
+   - Include a Codex co-author trailer in commit messages:
+
+```text
+Co-authored-by: Codex <codex@openai.com>
+```
+
+   - For multi-line commit messages, use `git commit -m "Summary" -m "Co-authored-by: Codex <codex@openai.com>"`.
+   - Push the branch and update or create the draft PR.
+   - Keep PR title/body aligned with the final set of paper additions and validation.
+
+## Classification Guidance
+
+- Use `Numerical Analysis, LLM` for LLM-assisted computational mathematics papers centered on numerical methods.
+- Use `Algebraic Geometry, Number Theory` for p-adic/nonabelian Hodge or arithmetic geometry papers unless the paper explicitly emphasizes formal proof or LLM methodology.
+- Add `ATP` only when the paper uses automated/formal theorem proving or proof assistant artifacts.
+- Add `LLM` when the abstract or resources describe language models, agentic AI systems, AI-generated proof drafts, or AI-assisted research workflow.

--- a/.agents/skills/awesome-ai-for-math-paper/agents/openai.yaml
+++ b/.agents/skills/awesome-ai-for-math-paper/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AI-for-Math Paper"
+  short_description: "Add paper links to the awesome-ai-for-math README"
+  default_prompt: "Use $awesome-ai-for-math-paper to add this paper link to the awesome-ai-for-math README."

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 
-A curated list of 182 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
+A curated list of 184 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
 
 See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main/CONTRIBUTING.md) for contribution.
 
@@ -101,6 +101,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 | **[Int2Int: a framework for mathematics with transformers](https://doi.org/10.4310/atmp.260412100858)** | Number Theory, Transformer | Advances in Theoretical and Mathematical Physics 2026 | [Code](https://github.com/f-charton/Int2Int) [arXiv](https://arxiv.org/abs/2502.17513) |
 | **[Interpretable Machine Learning for Kronecker Coefficients](https://doi.org/10.4310/atmp.260413002916)** | Representation Theory, Neural Network, Symbolic Computation, PCA, Transformer | Advances in Theoretical and Mathematical Physics 2026 | [arXiv](https://arxiv.org/abs/2502.11774) |
 | **[Irrationality of rapidly converging series: a problem of Erdős and Graham](https://arxiv.org/abs/2601.21442)** | Number Theory, LLM | arXiv 2026 | [Chat Logs](https://github.com/google-deepmind/superhuman/tree/main/aletheia) |
+| **[Iteris: Agentic Research Loops for Computational Mathematics](https://arxiv.org/abs/2606.02484)** | Numerical Analysis, LLM | arXiv 2026 | [Code](https://github.com/frenzymath/iteris) |
 | **[Lattice-Valued Bottleneck Duality](https://arxiv.org/abs/2410.00315)** | Combinatorics | arXiv 2024 |  |
 | **[LeanMarathon: Toward Reliable AI Co-Mathematicians through Long-Horizon Lean Autoformalization](https://arxiv.org/abs/2606.05400)** | ATP, LLM | arXiv 2026 | [Code](https://github.com/YuanheZ/LeanMarathon) |
 | **[LEAP: Supercharging LLMs for Formal Mathematics with Agentic Frameworks](https://arxiv.org/abs/2606.03303)** | ATP, LLM | arXiv 2026 |  |
@@ -113,6 +114,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 | **[Learning to compute Gröbner Basis](https://proceedings.neurips.cc/paper_files/paper/2024/hash/3a1de90699eec7d7f42c91d81f94af16-Abstract-Conference.html)** | Algebraic Geometry, Transformer | NeurIPS 2024 | [Code](https://github.com/HiroshiKERA/transformer-groebner) |
 | **[Learning Topological Invariance](https://arxiv.org/abs/2504.12390)** | Knot Theory, Neural Network, Transformer | arXiv 2025 |  |
 | **[LemmaBench: A Live, Research-Level Benchmark to Evaluate LLM Capabilities in Mathematics](https://arxiv.org/abs/2602.24173)** | Benchmark, LLM | arXiv 2026 |  |
+| **[Lift-independence problem in the $P$-adic Simpson correspondence for curves](https://arxiv.org/abs/2605.29947)** | Algebraic Geometry, Number Theory | arXiv 2026 | [Code (Rethlas)](https://github.com/frenzymath/Rethlas) |
 | **[Linear algebra with transformers](https://openreview.net/forum?id=Hp4g7FAXXG)** | Linear Algebra, Symbolic Computation, Transformer | TMLR 2022 | [Code](https://github.com/facebookresearch/LAWT) |
 | **[Lower bounds for multivariate independence polynomials and their generalisations](https://www.arxiv.org/abs/2602.02450)** | Combinatorics, LLM | arXiv 2026 | [Chat Logs](https://github.com/google-deepmind/superhuman/tree/main/aletheia) |
 | **[MA-ProofBench: A Two-Tiered Evaluation of LLMs for Theorem Proving in Mathematical Analysis](https://arxiv.org/abs/2606.13782)** | Benchmark, ATP, LLM | arXiv 2026 |  |


### PR DESCRIPTION
## Summary

Adds two arXiv papers to the README paper table:

- “Lift-independence problem in the $P$-adic Simpson correspondence for curves” with `Code (Rethlas)`
- “Iteris: Agentic Research Loops for Computational Mathematics” with its dedicated code repo, `https://github.com/frenzymath/iteris`

Also updates the README paper count from 182 to 184.

Adds a repo-local Codex skill at `.agents/skills/awesome-ai-for-math-paper/` for future paper-add workflow reuse: metadata extraction, topic classification, associated resource discovery, README validation, PR update flow, and Codex co-author trailers.

## Impact

This updates README paper metadata and adds a repo-local workflow skill. No generated assets, charts, or site data were changed.

## Validation

- Ran `rg -c '^\\| \\*\\*\\[' README.md` and confirmed the table has 184 paper rows.
- Verified `https://github.com/frenzymath/Rethlas` and `https://github.com/frenzymath/iteris` are public before adding resource links.
- Checked the repo-local skill frontmatter locally for required `name` and `description` fields.
- Attempted the bundled skill validator, but this Python environment is missing `yaml` / PyYAML, so that validator could not run.