### PR TITLE
Add Hierarchical RL for Sparse-Reward Search in Commutative Algebra

### DIFF
--- a/.agents/skills/awesome-ai-for-math-paper/SKILL.md
+++ b/.agents/skills/awesome-ai-for-math-paper/SKILL.md
@@ -24,6 +24,7 @@ Use this workflow for the `awesome-ai-for-math` repository unless the user gives
    - Subject(s): prefer existing README tags. Use mathematical domain tags first, then method tags such as `LLM`, `ATP`, `RL`, `Transformer`, `Neural Network`, or `Benchmark`.
    - Venue & Year: use `arXiv YYYY` unless a published venue is confirmed.
    - Links & Resources: include official resources discovered from the paper page, abstract, paper PDF, repository search, author pages, or clearly related existing project repos.
+   - Add an `[arXiv]` link to the last column only when the title links to a different published version (journal or conference) and the arXiv link would not duplicate it. If the title already links to the arXiv page, do not repeat an `[arXiv]` link in the last column.
 
 4. Search for associated resources.
    - Check the paper page and PDF for URLs such as GitHub, GitLab, project pages, datasets, notebooks, Lean artifacts, or chat logs.

--- a/.claude/skills/awesome-ai-for-math-paper/SKILL.md
+++ b/.claude/skills/awesome-ai-for-math-paper/SKILL.md
@@ -24,6 +24,7 @@ Use this workflow for the `awesome-ai-for-math` repository unless the user gives
    - Subject(s): prefer existing README tags. Use mathematical domain tags first, then method tags such as `LLM`, `ATP`, `RL`, `Transformer`, `Neural Network`, or `Benchmark`.
    - Venue & Year: use `arXiv YYYY` unless a published venue is confirmed.
    - Links & Resources: include official resources discovered from the paper page, abstract, paper PDF, repository search, author pages, or clearly related existing project repos.
+   - Add an `[arXiv]` link to the last column only when the title links to a different published version (journal or conference) and the arXiv link would not duplicate it. If the title already links to the arXiv page, do not repeat an `[arXiv]` link in the last column.
 
 4. Search for associated resources.
    - Check the paper page and PDF for URLs such as GitHub, GitLab, project pages, datasets, notebooks, Lean artifacts, or chat logs.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 
-A curated list of 184 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
+A curated list of 185 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
 
 See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main/CONTRIBUTING.md) for contribution.
 
@@ -93,6 +93,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 | **[Global Lyapunov functions: a long-standing open problem in mathematics, with symbolic transformers](https://proceedings.neurips.cc/paper_files/paper/2024/file/aa280e73c4e23e765fde232571116d3b-Paper-Conference.pdf)** | Differential Equations, Transformer | NeurIPS 2024 | [Code](https://github.com/facebookresearch/Lyapunov) |
 | **[Gödel Test: Can Large Language Models Solve Easy Conjectures?](https://arxiv.org/abs/2509.18383)** | Discrete Mathematics, LLM | arXiv 2025 |  |
 | **[HARDMath: A Benchmark Dataset for Challenging Problems in Applied Mathematics](https://arxiv.org/abs/2410.09988)** | Benchmark, LLM | arXiv 2024 | [Code](https://github.com/sarahmart/HARDMath) |
+| **[Hierarchical Reinforcement Learning for Sparse-Reward Search in Commutative Algebra](https://arxiv.org/abs/2606.22922)** | Commutative Algebra, Combinatorics, RL, Neural Network | ICML 2026 | [Code](https://github.com/Math-AI-Caltech/alghirsch-hrl) |
 | **[Hilbert series, machine learning, and applications to physics](https://www.sciencedirect.com/science/article/pii/S0370269322001009)** | Algebraic Geometry, Mathematical Physics, Neural Network | Physics Letters B 2024 | [Code](https://github.com/edhirst/HilbertSeriesML) |
 | **[Humanity's Last Exam](https://doi.org/10.1038/s41586-025-09962-4)** | Benchmark, LLM | Nature 2026 | [Website](https://lastexam.ai) [arXiv](https://arxiv.org/abs/2501.14249) |
 | **[Illuminating new and known relations between knot invariants](https://doi.org/10.1088/2632-2153/ad95d9)** | Knot Theory, Neural Network | Machine Learning: Science and Technology 2024 | [Code](https://github.com/JessRachel97/Knot_searcher_experiments) [arXiv](https://arxiv.org/abs/2211.01404) |


### PR DESCRIPTION
## Summary
Adds the ICML 2026 paper [Hierarchical Reinforcement Learning for Sparse-Reward Search in Commutative Algebra](https://arxiv.org/abs/2606.22922) to the README table.

- **Subjects:** Commutative Algebra, Combinatorics, RL, Neural Network — recasts Kalai's algebraic Hirsch conjecture as a sparse-reward RL problem with a constrained options-based HRL framework and an equivariant GNN policy.
- **Venue & Year:** ICML 2026 (confirmed accepted per arXiv comments).
- **Links:** `[Code]` → https://github.com/Math-AI-Caltech/alghirsch-hrl (no duplicate arXiv link since the title already links to the arXiv page).
- Paper count bumped 184 → 185; row inserted alphabetically between *HARDMath* and *Hilbert series*.

Also updates both skill files (`.claude` and `.agents`) to document the rule: only add an `[arXiv]` link in the last column when the title links to a different published version, to avoid duplicates.

## Validation
- `rg -c '^\| \*\*\[' README.md` → 185, matching the intro count.
- `git diff` inspected; only README + skill files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)