### PR TITLE
Add 2 geometry-of-numbers / sphere-packing papers (LLM-assisted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 
 | Title | Subject(s) | Venue & Year | Links & Resources |
 | :--- | :--- | :--- | :--- |
-| **[A dual linear programming bound for sphere packing in dimension 36](https://arxiv.org/abs/2607.11319)** | Discrete Geometry, Number Theory, LLM | arXiv 2026 |  |
+| **[A dual linear programming bound for sphere packing in dimension 36](https://arxiv.org/abs/2607.11319)** | Discrete Geometry, Number Theory, LLM | arXiv 2026 | [Code](https://arxiv.org/src/2607.11319/anc) |
 | **[A Machine Learning Approach That Beats Large Rubik's Cubes](https://arxiv.org/abs/2502.13266)** | Graph Theory, Group Theory, RL | arXiv 2025 | [Code](https://github.com/cayleypy/cayleypy) |
 | **[A Machine Learning Approach to the Nirenberg Problem](https://arxiv.org/abs/2602.12368)** | Differential Geometry, PINN | arXiv 2026 | [Code](https://github.com/xand-stapleton/nirenberg-neural-network) |
 | **[A Systematization of the Wagner Framework: Graph Theory Conjectures and Reinforcement Learning](https://doi.org/10.1007/978-3-031-78977-9_21)** | Graph Theory, RL | Discovery Science 2025 | [Code](https://github.com/CuriosAI/graph_conjectures) [arXiv](https://arxiv.org/abs/2406.12667) |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 
-A curated list of 188 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
+A curated list of 189 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
 
 See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main/CONTRIBUTING.md) for contribution.
 
@@ -14,6 +14,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 
 | Title | Subject(s) | Venue & Year | Links & Resources |
 | :--- | :--- | :--- | :--- |
+| **[A dual linear programming bound for sphere packing in dimension 36](https://arxiv.org/abs/2607.11319)** | Discrete Geometry, Number Theory, LLM | arXiv 2026 |  |
 | **[A Machine Learning Approach That Beats Large Rubik's Cubes](https://arxiv.org/abs/2502.13266)** | Graph Theory, Group Theory, RL | arXiv 2025 | [Code](https://github.com/cayleypy/cayleypy) |
 | **[A Machine Learning Approach to the Nirenberg Problem](https://arxiv.org/abs/2602.12368)** | Differential Geometry, PINN | arXiv 2026 | [Code](https://github.com/xand-stapleton/nirenberg-neural-network) |
 | **[A Systematization of the Wagner Framework: Graph Theory Conjectures and Reinforcement Learning](https://doi.org/10.1007/978-3-031-78977-9_21)** | Graph Theory, RL | Discovery Science 2025 | [Code](https://github.com/CuriosAI/graph_conjectures) [arXiv](https://arxiv.org/abs/2406.12667) |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 
-A curated list of 187 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
+A curated list of 188 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
 
 See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main/CONTRIBUTING.md) for contribution.
 
@@ -156,6 +156,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 | **[On (not) learning the Möbius function](https://arxiv.org/abs/2604.23427)** | Number Theory | arXiv 2026 |  |
 | **[On the paucity of lattice triangles](https://arxiv.org/abs/2603.23928)** | Geometry, Number Theory, Combinatorics, ATP | arXiv 2026 | [Code](https://github.com/AxiomMath/lattice-triangle) |
 | **[On the Quartic Invariant of Odd Degree Binary Forms](https://arxiv.org/abs/2603.24330)** | Algebraic Geometry, Number Theory, LLM, ATP | arXiv 2026 | [Code](https://github.com/ashvin-swaminathan/quartic-invariant) |
+| **[On two counterexamples in the geometry of numbers](https://arxiv.org/abs/2607.11695)** | Discrete Geometry, Number Theory, LLM | arXiv 2026 |  |
 | **[Optimal bounds for an Erdős problem on matching integers to distinct multiples](https://arxiv.org/abs/2603.28636)** | Number Theory, Combinatorics, ATP | arXiv 2026 | [Code](https://github.com/Woett/Lean-files/blob/main/ErdosProblem650.lean) |
 | **[Parity of k-differentials in genus zero and one](https://arxiv.org/abs/2602.03722)** | Algebraic Geometry, Number Theory, ATP | arXiv 2026 | [Code](https://github.com/AxiomMath/parity-differential) |
 | **[PatternBoost: Constructions in Mathematics with a Little Help from AI](https://arxiv.org/abs/2411.00566)** | Discrete Geometry, Combinatorics, Transformer, RL | arXiv 2024 | [Code](https://github.com/zawagner22/transformers_math_experiments) |


### PR DESCRIPTION
Adds two arXiv 2026 papers where LLM tools were used to find/construct the results.

### 1. [On two counterexamples in the geometry of numbers](https://arxiv.org/abs/2607.11695) — Nihar Gargava
- **Subject(s):** Discrete Geometry, Number Theory, LLM
- Counterexamples in dimensions 8 and 9 (Cartesian-product problem on critical determinants / lattice packings; height minimization for flat tori), found using ChatGPT 5.5 Pro.
- **Links:** none — chat logs "available on request" (not public); reproduction scripts in arXiv ancillary files.

### 2. [A dual linear programming bound for sphere packing in dimension 36](https://arxiv.org/abs/2607.11319) — Rifat Jumagulov
- **Subject(s):** Discrete Geometry, Number Theory, LLM
- Explicit dual-feasible point for the Cohn–Elkies LP in dimension 36; construction and manuscript carried out "with substantial assistance from AI language-model tools" (result itself is exact & machine-checkable).
- **Links:** none — machine-checkable certificate and pure-Python verification code are in arXiv ancillary files (no separate repo).

Validation:
- Both rows inserted in case-insensitive alphabetical order (matching the repo's auto-sort).
- Paper count bumped 187 → 189; `rg -c '^\| \*\*\[' README.md` matches the intro.
- README-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)