### PR TITLE
Add 'Beyond Mock Modularity: Elliptic Corrections for Higher Dyson Ranks'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 
-A curated list of 189 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
+A curated list of 190 awesome papers exploring the use of artificial intelligence / machine learning / deep learning for mathematical discoveries.
 
 See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main/CONTRIBUTING.md) for contribution.
 
@@ -46,6 +46,7 @@ See [`CONTRIBUTING.md`](https://github.com/seewoo5/awesome-ai-for-math/blob/main
 | **[Automated Conjecture Resolution with Formal Verification](https://arxiv.org/abs/2604.03789)** | LLM, ATP | arXiv 2026 | [Code (Rethlas)](https://github.com/frenzymath/Rethlas), [Code (Archon)](https://github.com/frenzymath/Archon), [Code (Lean)](https://github.com/frenzymath/Anderson-Conjecture) |
 | **[Automated Search for Conjectures on Mathematical Constants using Analysis of Integer Sequences](https://proceedings.mlr.press/v202/razon23a.html)** | Number Theory | ICML 2023 | [Code](https://github.com/RamanujanMachine/) |
 | **[Benchmarks in Leipzig](https://arxiv.org/abs/2606.05818)** | Benchmark, LLM | arXiv 2026 |  |
+| **[Beyond Mock Modularity: Elliptic Corrections for Higher Dyson Ranks](https://arxiv.org/abs/2607.13159)** | Combinatorics, Number Theory, ATP | arXiv 2026 | [Code](https://github.com/AxiomMath/HigherDyson) |
 | **[Can Transformers Do Enumerative Geometry?](https://proceedings.iclr.cc/paper_files/paper/2025/file/aee2f03ecb2b2c1ea55a43946b651cfd-Paper-Conference.pdf)** | Algebraic Geometry, Interpretability, Transformer | ICLR 2025 | [Code](https://github.com/Baran-phys/DynamicFormer) |
 | **[CayleyPy RL: Pathfinding and Reinforcement Learning on Cayley Graphs](https://doi.org/10.4310/atmp.260413005111)** | Graph Theory, Group Theory, RL | Advances in Theoretical and Mathematical Physics 2026 | [Code](https://github.com/cayleypy/cayleypy) [arXiv](https://arxiv.org/abs/2502.18663) |
 | **[Certifying Arithmeticity for Two Degree-Six Symplectic Hypergeometric Monodromy Groups](https://arxiv.org/abs/2605.25935)** | Number Theory, LLM | arXiv 2026 | [Code](https://github.com/ditahd/Certificates) |


### PR DESCRIPTION
Adds one paper to the README table.

## Paper

**[Beyond Mock Modularity: Elliptic Corrections for Higher Dyson Ranks](https://arxiv.org/abs/2607.13159)** — Claudia Alfes, Ken Ono, Ashvin Swaminathan (arXiv:2607.13159, submitted 2026-07-14)

| Field | Value |
| --- | --- |
| Subject(s) | Combinatorics, Number Theory, ATP |
| Venue & Year | arXiv 2026 |
| Links | [Code](https://github.com/AxiomMath/HigherDyson) |

## Field selection

- **Subjects**: arXiv categories are `math.NT` (primary) and `math.CO`, giving the Number Theory and Combinatorics domain tags. `ATP` applies — the key formulas were "formalized and machine-verified in Lean/Mathlib by AxiomProver," and the repo holds the resulting Lean artifacts.
- **No `LLM` tag**: the paper describes AxiomProver only as "an AI system for mathematical research via formal proof," and speaks of a "human--AI collaboration" and "generative AI." It never refers to a language model or LLM. Comparable rows carrying the `LLM` tag do have an explicit mention (e.g. "Forbidden Sidon subsets" names ChatGPT and "a large language model"; "Automated Conjecture Resolution" opens on "large language models"), so the tag is omitted here.
- **Links**: The repository is not linked from the arXiv abstract page or HTML rendering — the acknowledgements thank Kenny Lau for assembling it but give no URL. It was found in the arXiv LaTeX source under the Artifacts section, and hosts the AxiomProver input files plus generated `problem.lean` outputs across four batches. `Code` is used rather than `Chat Logs` since the repo holds Lean artifacts.
- **No `[arXiv]` link** in the last column: the title already links to the arXiv page, so it would duplicate.

## Validation

- Metadata confirmed against the arXiv Atom API (not just the abstract page).
- Repository URL verified to resolve (HTTP 200).
- Row inserted alphabetically between "Benchmarks in Leipzig" and "Can Transformers Do Enumerative Geometry?".
- Paper count bumped 189 → 190; `rg -c '^\| \*\*\[' README.md` returns 190, matching the intro.
- README-only change; `assets/papers.json` and charts untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)