### PR TITLE
Fix false arXiv publication matches

### DIFF
--- a/.github/workflows/test-arxiv-link-updater.yml
+++ b/.github/workflows/test-arxiv-link-updater.yml
@@ -1,0 +1,37 @@
+name: Test arXiv link updater
+
+on:
+  pull_request:
+    paths:
+      - update_arxiv_links.py
+      - tests/test_update_arxiv_links.py
+      - .github/workflows/test-arxiv-link-updater.yml
+  push:
+    branches:
+      - main
+    paths:
+      - update_arxiv_links.py
+      - tests/test_update_arxiv_links.py
+      - .github/workflows/test-arxiv-link-updater.yml
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run unit tests
+        run: python -m unittest discover -s tests -v

--- a/tests/test_update_arxiv_links.py
+++ b/tests/test_update_arxiv_links.py
@@ -1,109 +1,37 @@
-import tempfile
 import unittest
-from pathlib import Path
-from unittest.mock import Mock, patch
 
 import update_arxiv_links
 
 
-class CrossRefMatchingTests(unittest.TestCase):
-    @patch("update_arxiv_links.requests.get")
-    def test_rejects_similar_title_with_different_authors(self, mock_get):
-        response = Mock()
-        response.raise_for_status.return_value = None
-        response.json.return_value = {
-            "message": {
-                "items": [
-                    {
-                        "DOI": "10.1017/s0963548322000360",
-                        "title": ["Off-diagonal book Ramsey numbers"],
-                        "author": [
-                            {"family": "Conlon"},
-                            {"family": "Fox"},
-                            {"family": "Wigderson"},
-                        ],
-                        "container-title": [
-                            "Combinatorics, Probability and Computing"
-                        ],
-                        "published": {"date-parts": [[2023]]},
-                    }
-                ]
-            }
-        }
-        mock_get.return_value = response
-
-        result = update_arxiv_links.query_crossref_by_title(
-            "Off-diagonal Ramsey numbers",
-            ["Domagoj Bradač"],
-        )
-
-        self.assertIsNone(result)
-
-    @patch("update_arxiv_links.requests.get")
-    def test_accepts_similar_title_with_matching_author(self, mock_get):
-        response = Mock()
-        response.raise_for_status.return_value = None
-        response.json.return_value = {
-            "message": {
-                "items": [
-                    {
-                        "DOI": "10.1234/example",
-                        "title": ["Off-diagonal Ramsey numbers"],
-                        "author": [{"family": "Bradac"}],
-                        "container-title": ["Example Journal"],
-                        "published": {"date-parts": [[2026]]},
-                    }
-                ]
-            }
-        }
-        mock_get.return_value = response
-
-        result = update_arxiv_links.query_crossref_by_title(
-            "Off-diagonal Ramsey numbers",
-            ["Domagoj Bradač"],
-        )
-
-        self.assertEqual(result["doi"], "10.1234/example")
-        self.assertEqual(result["venue"], "Example Journal 2026")
-
-
-class ReadmeUpdateTests(unittest.TestCase):
-    @patch("update_arxiv_links.time.sleep")
-    @patch("update_arxiv_links.query_crossref_by_title", return_value=None)
-    @patch("update_arxiv_links.query_crossref_by_doi")
-    @patch("update_arxiv_links.query_arxiv")
-    def test_rejects_mismatched_doi_supplied_by_arxiv(
-        self,
-        mock_arxiv,
-        mock_crossref_by_doi,
-        _mock_crossref_by_title,
-        _mock_sleep,
-    ):
-        mock_arxiv.return_value = {
-            "title": "Off-diagonal Ramsey numbers",
-            "doi": "10.1017/s0963548322000360",
-            "authors": ["Domagoj Bradač"],
-        }
-        mock_crossref_by_doi.return_value = {
-            "doi": "10.1017/s0963548322000360",
+class MetadataMatchingTests(unittest.TestCase):
+    def test_requires_matching_title_and_author(self):
+        arxiv_title = "Off-diagonal Ramsey numbers"
+        arxiv_authors = ["Domagoj Bradač"]
+        unrelated_paper = {
             "title": "Off-diagonal book Ramsey numbers",
             "authors": ["Conlon", "Fox", "Wigderson"],
-            "venue": "Combinatorics, Probability and Computing 2023",
         }
-        row = (
-            "| **[Off-diagonal Ramsey numbers]"
-            "(https://arxiv.org/abs/2605.28793)** "
-            "| Combinatorics, LLM | arXiv 2026 |  |\n"
+
+        self.assertGreaterEqual(
+            update_arxiv_links.title_similarity(
+                arxiv_title,
+                unrelated_paper["title"],
+            ),
+            update_arxiv_links.TITLE_THRESHOLD,
+        )
+        self.assertFalse(
+            update_arxiv_links.metadata_matches(
+                arxiv_title,
+                arxiv_authors,
+                unrelated_paper,
+            )
         )
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            readme = Path(temp_dir) / "README.md"
-            readme.write_text(row, encoding="utf-8")
-
-            update_arxiv_links.update_readme(str(readme), str(readme))
-
-            self.assertEqual(readme.read_text(encoding="utf-8"), row)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        matching_paper = {"title": arxiv_title, "authors": ["Bradac"]}
+        self.assertTrue(
+            update_arxiv_links.metadata_matches(
+                arxiv_title,
+                arxiv_authors,
+                matching_paper,
+            )
+        )

--- a/tests/test_update_arxiv_links.py
+++ b/tests/test_update_arxiv_links.py
@@ -1,0 +1,109 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import update_arxiv_links
+
+
+class CrossRefMatchingTests(unittest.TestCase):
+    @patch("update_arxiv_links.requests.get")
+    def test_rejects_similar_title_with_different_authors(self, mock_get):
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "message": {
+                "items": [
+                    {
+                        "DOI": "10.1017/s0963548322000360",
+                        "title": ["Off-diagonal book Ramsey numbers"],
+                        "author": [
+                            {"family": "Conlon"},
+                            {"family": "Fox"},
+                            {"family": "Wigderson"},
+                        ],
+                        "container-title": [
+                            "Combinatorics, Probability and Computing"
+                        ],
+                        "published": {"date-parts": [[2023]]},
+                    }
+                ]
+            }
+        }
+        mock_get.return_value = response
+
+        result = update_arxiv_links.query_crossref_by_title(
+            "Off-diagonal Ramsey numbers",
+            ["Domagoj Bradač"],
+        )
+
+        self.assertIsNone(result)
+
+    @patch("update_arxiv_links.requests.get")
+    def test_accepts_similar_title_with_matching_author(self, mock_get):
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "message": {
+                "items": [
+                    {
+                        "DOI": "10.1234/example",
+                        "title": ["Off-diagonal Ramsey numbers"],
+                        "author": [{"family": "Bradac"}],
+                        "container-title": ["Example Journal"],
+                        "published": {"date-parts": [[2026]]},
+                    }
+                ]
+            }
+        }
+        mock_get.return_value = response
+
+        result = update_arxiv_links.query_crossref_by_title(
+            "Off-diagonal Ramsey numbers",
+            ["Domagoj Bradač"],
+        )
+
+        self.assertEqual(result["doi"], "10.1234/example")
+        self.assertEqual(result["venue"], "Example Journal 2026")
+
+
+class ReadmeUpdateTests(unittest.TestCase):
+    @patch("update_arxiv_links.time.sleep")
+    @patch("update_arxiv_links.query_crossref_by_title", return_value=None)
+    @patch("update_arxiv_links.query_crossref_by_doi")
+    @patch("update_arxiv_links.query_arxiv")
+    def test_rejects_mismatched_doi_supplied_by_arxiv(
+        self,
+        mock_arxiv,
+        mock_crossref_by_doi,
+        _mock_crossref_by_title,
+        _mock_sleep,
+    ):
+        mock_arxiv.return_value = {
+            "title": "Off-diagonal Ramsey numbers",
+            "doi": "10.1017/s0963548322000360",
+            "authors": ["Domagoj Bradač"],
+        }
+        mock_crossref_by_doi.return_value = {
+            "doi": "10.1017/s0963548322000360",
+            "title": "Off-diagonal book Ramsey numbers",
+            "authors": ["Conlon", "Fox", "Wigderson"],
+            "venue": "Combinatorics, Probability and Computing 2023",
+        }
+        row = (
+            "| **[Off-diagonal Ramsey numbers]"
+            "(https://arxiv.org/abs/2605.28793)** "
+            "| Combinatorics, LLM | arXiv 2026 |  |\n"
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            readme = Path(temp_dir) / "README.md"
+            readme.write_text(row, encoding="utf-8")
+
+            update_arxiv_links.update_readme(str(readme), str(readme))
+
+            self.assertEqual(readme.read_text(encoding="utf-8"), row)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_arxiv_links.py
+++ b/update_arxiv_links.py
@@ -8,10 +8,12 @@ For each README row whose title links to an arXiv preprint, we attempt to
 find the official peer-reviewed DOI via two authoritative sources, in order:
 
   1. arXiv API  — some authors add the published DOI to their arXiv submission
-                  after acceptance; this is the most direct source.
+                  after acceptance; the DOI is verified against CrossRef before
+                  it is accepted.
   2. CrossRef   — the DOI registration agency used by virtually all major
                   journals; searched by paper title, accepted only when the
-                  returned title is sufficiently similar to ours (≥ TITLE_THRESHOLD).
+                  returned title is sufficiently similar to ours (≥ TITLE_THRESHOLD)
+                  and at least one author surname agrees.
 
 If a DOI is found, the following columns are updated:
   - Title:   the arXiv link is replaced with https://doi.org/{DOI}
@@ -37,6 +39,7 @@ import sys
 import shutil
 import time
 import difflib
+import unicodedata
 import xml.etree.ElementTree as ET
 import requests
 
@@ -83,12 +86,12 @@ def query_arxiv(arxiv_id: str) -> dict | None:
     """
     Fetch metadata for a single paper from the arXiv Atom API.
 
-    Returns a dict {'title': str, 'doi': str | None}, or None on network /
-    parse error. The title has internal whitespace normalised (arXiv XML often
-    contains newlines inside the title element). The doi field is the
-    journal-ref DOI submitted by the authors after publication, or None if they
-    have not added one. It is NOT filtered for preprint prefixes here because
-    authors would not normally set their own DOI to an arXiv or preprint DOI.
+    Returns a dict {'title': str, 'doi': str | None, 'authors': list[str]}, or
+    None on network / parse error. The title has internal whitespace normalised
+    (arXiv XML often contains newlines inside the title element). The doi field
+    is the journal-ref DOI submitted by the authors after publication, or None
+    if they have not added one. It is still verified against CrossRef metadata
+    before use.
     """
     try:
         r = requests.get(ARXIV_API, params={"id_list": arxiv_id}, timeout=15)
@@ -105,11 +108,17 @@ def query_arxiv(arxiv_id: str) -> dict | None:
     entry = entries[0]
     title_el = entry.find("atom:title", ARXIV_NS)
     doi_el   = entry.find("arxiv:doi",  ARXIV_NS)
+    author_els = entry.findall("atom:author/atom:name", ARXIV_NS)
 
     return {
         # Collapse whitespace: arXiv XML titles may contain literal newlines.
         "title": " ".join(title_el.text.split()) if title_el is not None else "",
         "doi":   doi_el.text.strip()              if doi_el   is not None else None,
+        "authors": [
+            " ".join(author_el.text.split())
+            for author_el in author_els
+            if author_el.text
+        ],
     }
 
 
@@ -120,6 +129,48 @@ def query_arxiv(arxiv_id: str) -> dict | None:
 def title_similarity(a: str, b: str) -> float:
     """Return case-insensitive SequenceMatcher ratio between two title strings."""
     return difflib.SequenceMatcher(None, a.lower(), b.lower()).ratio()
+
+
+def author_surname(author: str) -> str:
+    """
+    Return a comparison key for an author surname.
+
+    arXiv exposes full names while CrossRef has a dedicated family-name field.
+    Comparing their final normalised token handles accents (for example,
+    "Bradač" versus "Bradac") and multi-word family names conservatively enough
+    for use alongside the existing title-similarity threshold.
+    """
+    ascii_name = unicodedata.normalize("NFKD", author).encode("ascii", "ignore").decode()
+    tokens = re.findall(r"[a-z0-9]+", ascii_name.lower())
+    return tokens[-1] if tokens else ""
+
+
+def authors_overlap(arxiv_authors: list[str], crossref_authors: list[str]) -> bool:
+    """Return whether the two metadata records share an author surname."""
+    arxiv_surnames = {author_surname(author) for author in arxiv_authors}
+    crossref_surnames = {author_surname(author) for author in crossref_authors}
+    arxiv_surnames.discard("")
+    crossref_surnames.discard("")
+    return bool(arxiv_surnames & crossref_surnames)
+
+
+def metadata_matches(
+    arxiv_title: str,
+    arxiv_authors: list[str],
+    crossref_item: dict,
+) -> bool:
+    """
+    Return whether CrossRef metadata confidently describes the arXiv paper.
+
+    Title similarity alone is not sufficient for short, generic titles:
+    "Off-diagonal Ramsey numbers" and the unrelated "Off-diagonal book Ramsey
+    numbers" score 0.915, above TITLE_THRESHOLD. Requiring an author match
+    rejects that false positive and other similarly named papers.
+    """
+    return (
+        title_similarity(arxiv_title, crossref_item.get("title", "")) >= TITLE_THRESHOLD
+        and authors_overlap(arxiv_authors, crossref_item.get("authors", []))
+    )
 
 
 def extract_venue_from_item(item: dict) -> str:
@@ -150,15 +201,31 @@ def extract_venue_from_item(item: dict) -> str:
     return f"{venue_name} {year}".strip()
 
 
-def query_crossref_by_title(title: str) -> dict | None:
+def extract_crossref_metadata(item: dict) -> dict:
+    """Extract the DOI, title, author surnames, and venue from a CrossRef item."""
+    titles = item.get("title", [])
+    authors = [
+        author.get("family", "")
+        for author in item.get("author", [])
+        if author.get("family")
+    ]
+    return {
+        "doi": item.get("DOI", ""),
+        "title": titles[0] if titles else "",
+        "authors": authors,
+        "venue": extract_venue_from_item(item),
+    }
+
+
+def query_crossref_by_title(title: str, authors: list[str]) -> dict | None:
     """
     Search CrossRef for a paper by title.
 
-    Fetches the top 3 scored results and returns a dict
-    {'doi': str, 'venue': str} for the first result whose title similarity
-    exceeds TITLE_THRESHOLD. Results whose DOI belongs to a known preprint
-    server (PREPRINT_DOI_PREFIXES) are skipped before the similarity check,
-    since CrossRef sometimes indexes preprints alongside journal articles.
+    Fetches the top 3 scored results and returns metadata for the first result
+    whose title similarity exceeds TITLE_THRESHOLD and whose authors overlap
+    the arXiv authors. Results whose DOI belongs to a known preprint server
+    (PREPRINT_DOI_PREFIXES) are skipped before the metadata checks, since
+    CrossRef sometimes indexes preprints alongside journal articles.
 
     Returns None if no sufficiently similar peer-reviewed match is found.
     The 'venue' value may be an empty string if CrossRef has no container-title.
@@ -169,7 +236,7 @@ def query_crossref_by_title(title: str) -> dict | None:
             params={
                 "query.title": title,
                 "rows": 3,
-                "select": "DOI,title,container-title,published",
+                "select": "DOI,title,author,container-title,published",
             },
             timeout=15,
         )
@@ -180,14 +247,14 @@ def query_crossref_by_title(title: str) -> dict | None:
         return None
 
     for item in items:
-        cr_titles = item.get("title", [])
-        if not cr_titles:
+        metadata = extract_crossref_metadata(item)
+        if not metadata["title"]:
             continue
-        doi = item.get("DOI", "")
+        doi = metadata["doi"]
         if any(doi.startswith(p) for p in PREPRINT_DOI_PREFIXES):
             continue  # skip preprint server entries
-        if title_similarity(title, cr_titles[0]) >= TITLE_THRESHOLD:
-            return {"doi": doi, "venue": extract_venue_from_item(item)}
+        if metadata_matches(title, authors, metadata):
+            return metadata
 
     return None
 
@@ -196,15 +263,15 @@ def query_crossref_by_doi(doi: str) -> dict | None:
     """
     Fetch venue metadata from CrossRef for a known DOI.
 
-    Used when the DOI was already found via the arXiv API and we only need the
-    venue name and year. Returns {'venue': str} or None on error.
-    The 'venue' value may be an empty string if CrossRef has no container-title.
+    Used when a DOI was found via the arXiv API. Its title and authors are
+    returned along with the venue so the caller can verify that the DOI belongs
+    to the same paper. Returns None on error.
     """
     try:
         r = requests.get(f"{CROSSREF_API}/{doi}", timeout=15)
         r.raise_for_status()
         item = r.json().get("message", {})
-        return {"venue": extract_venue_from_item(item)}
+        return extract_crossref_metadata(item)
     except Exception as e:
         print(f"\n  [crossref doi error] {e}")
         return None
@@ -291,17 +358,24 @@ def update_readme(input_path: str = README_PATH, output_path: str = README_PATH)
         time.sleep(ARXIV_DELAY)
         paper_title = meta["title"] if meta else ""
 
+        authors = meta.get("authors", []) if meta else []
+
         if meta and meta["doi"]:
-            doi = meta["doi"]
-            print("arXiv→DOI  ", end="", flush=True)
-            # DOI found via arXiv; fetch venue from CrossRef by DOI.
-            cr_meta = query_crossref_by_doi(doi)
+            # DOI found via arXiv; verify its title and authors against CrossRef
+            # before trusting it, then reuse the CrossRef venue metadata.
+            arxiv_doi = meta["doi"]
+            cr_meta = query_crossref_by_doi(arxiv_doi)
             time.sleep(CROSSREF_DELAY)
-            if cr_meta:
+            if cr_meta and metadata_matches(paper_title, authors, cr_meta):
+                doi = arxiv_doi
                 venue_str = cr_meta["venue"]
-        elif paper_title:
-            # Step 2: fall back to CrossRef title search.
-            cr_meta = query_crossref_by_title(paper_title)
+                print("arXiv→DOI  ", end="", flush=True)
+            else:
+                print("arXiv DOI metadata mismatch  ", end="", flush=True)
+
+        if not doi and paper_title:
+            # Step 2: fall back to CrossRef title-and-author search.
+            cr_meta = query_crossref_by_title(paper_title, authors)
             time.sleep(CROSSREF_DELAY)
             if cr_meta:
                 doi = cr_meta["doi"]


### PR DESCRIPTION
## Summary

- verify every DOI against both the arXiv title and at least one author surname
- apply the same verification to DOIs supplied directly by arXiv metadata
- add regression coverage for arXiv `2605.28793` and a lightweight pull-request test workflow

## Root cause

The Crossref title candidate `Off-diagonal book Ramsey numbers` has a `SequenceMatcher` score of about 0.915 against `Off-diagonal Ramsey numbers`, which exceeded the existing 0.90 threshold even though it is a different paper by different authors. The arXiv-supplied DOI path also trusted a DOI without validating its Crossref title or authors.

The README remains unchanged, so the correct arXiv link stays in place.

## Validation

- `/opt/homebrew/opt/python@3.10/bin/python3.10 -m unittest discover -s tests -v`
- `python3 -m py_compile update_arxiv_links.py tests/test_update_arxiv_links.py`
- `git diff --check`
- workflow YAML parse check